### PR TITLE
Add A --quiet Option To Surprise STDOUT Use

### DIFF
--- a/weather_check.py
+++ b/weather_check.py
@@ -139,6 +139,14 @@ if __name__ == "__main__":
                         help='Set log level to:'
                         ' DEBUG, INFO, WARNING, ERROR, CRITICAL')
 
+    parser.add_argument('--quiet',
+                        dest='quiet',
+                        action='store_true',
+                        required=False,
+                        help='Do not output result ot STDOUT')
+
+    parser.set_defaults(quiet=False)
+
     parser.add_argument('--secret',
                         type=str,
                         required=True,
@@ -171,5 +179,6 @@ if __name__ == "__main__":
         message = 'You don\'t need to worry about salt tonight.'
         logging.info(message)
 
+    if not arguments['quiet']:
         print(message)
 


### PR DESCRIPTION
If you use the --quiet option then no output will go to the command line
apart from any enabled logging.